### PR TITLE
Add sentry to package

### DIFF
--- a/.github/scripts/build_daprbundle.py
+++ b/.github/scripts/build_daprbundle.py
@@ -37,6 +37,7 @@ GITHUB_CLI_REPO="cli"
 # Dapr binaries filename
 DAPRD_FILENAME="daprd"
 PLACEMENT_FILENAME="placement"
+SENTRY_FILENAME="sentry"
 DASHBOARD_FILENAME="dashboard"
 CLI_FILENAME="dapr"
 DAPRBUNDLE_FILENAME="daprbundle"
@@ -135,6 +136,7 @@ def downloadBinaries(dir):
     bin_dir = os.path.join(dir,BIN_DIR)
     downloadBinary(GITHUB_DAPR_REPO,DAPRD_FILENAME,runtime_ver,bin_dir)
     downloadBinary(GITHUB_DAPR_REPO,PLACEMENT_FILENAME,runtime_ver,bin_dir)
+    downloadBinary(GITHUB_DAPR_REPO,SENTRY_FILENAME,runtime_ver,bin_dir)
     downloadBinary(GITHUB_DASHBOARD_REPO,DASHBOARD_FILENAME,dashboard_ver,bin_dir)
     downloadBinary(GITHUB_CLI_REPO,CLI_FILENAME,cli_ver,dir)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ daprbundle
 │   ├── daprd_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
 │   ├── dashboard_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
 │   ├── placement_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
+│   ├── sentry_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
 ├── docker
 │   ├── daprio/dapr-<runtime_ver>.tar.gz
 └── details.json


### PR DESCRIPTION
Signed-off-by: shivam <shivamkm07@gmail.com>

This PR adds sentry as part of the installer bundle for use of mtls in airgapped networks. 

Issue closed: #13 