### PR TITLE
Updating Readme

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARCHIVE_DIR: archives
-      README_FILE: README.md
+      README_MD_FILE: README.md
+      README_TXT_FILE: README.txt
     strategy:
       matrix:
         target_os: [linux, windows, darwin]
@@ -91,13 +92,18 @@ jobs:
           echo RUNTIME VERSION: ${{env.RUNTIME_VERSION}}
           echo GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}
       
+      - name: Create Readme.txt file
+        shell: bash
+        run: |
+          cp ${{env.README_MD_FILE}} ${{env.README_TXT_FILE}}
+      
       - name: Create and Archive bundle in workflow_dispatch
         if: github.event_name == 'workflow_dispatch'
-        run: python ./.github/scripts/build_daprbundle.py --runtime_os=${{matrix.target_os}} --runtime_arch=${{matrix.target_arch}} --archive_dir=${{env.ARCHIVE_DIR}} --runtime_ver=${{inputs.runtime_ver}} --cli_ver=${{inputs.cli_ver}} --dashboard_ver=${{inputs.dashboard_ver}} --added_files=${{env.README_FILE}}
+        run: python ./.github/scripts/build_daprbundle.py --runtime_os=${{matrix.target_os}} --runtime_arch=${{matrix.target_arch}} --archive_dir=${{env.ARCHIVE_DIR}} --runtime_ver=${{inputs.runtime_ver}} --cli_ver=${{inputs.cli_ver}} --dashboard_ver=${{inputs.dashboard_ver}} --added_files=${{env.README_TXT_FILE}}
 
       - name: Create and Archive bundle without workflow_dispatch
         if: github.event_name != 'workflow_dispatch'
-        run: python ./.github/scripts/build_daprbundle.py --runtime_os=${{matrix.target_os}} --runtime_arch=${{matrix.target_arch}} --archive_dir=${{env.ARCHIVE_DIR}} --runtime_ver=${{env.RUNTIME_VERSION}} --added_files=${{env.README_FILE}}
+        run: python ./.github/scripts/build_daprbundle.py --runtime_os=${{matrix.target_os}} --runtime_arch=${{matrix.target_arch}} --archive_dir=${{env.ARCHIVE_DIR}} --runtime_ver=${{env.RUNTIME_VERSION}} --added_files=${{env.README_TXT_FILE}}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@master

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In self-hosted mode, dapr can be initialized using the CLI  with the placement c
 
 ([Prerequisite](#Prerequisites): Docker is available in the environment - recommended)
 
-Use the init command to initialize Dapr. On init, multiple default configuration files and containers are installed along with the dapr runtime binary. Dapr runtime binary is installed under $HOME/.dapr/bin for Mac, Linux and %USERPROFILE%\.dapr\bin for Windows.
+Use the init command to initialize Dapr. On init, default configuration file and containers are installed along with the dapr runtime binary. Dapr runtime binary is installed under $HOME/.dapr/bin for Mac, Linux and %USERPROFILE%\.dapr\bin for Windows.
 
 Move to the bundle directory and run the following command:
 ``` bash
@@ -76,11 +76,10 @@ Output should look like as follows:
 
 This step creates the following defaults:
 
-1. components folder which is later used during `dapr run` unless the `--components-path` option is provided. For Linux/MacOS, the default components folder path is `$HOME/.dapr/components` and for Windows it is `%USERPROFILE%\.dapr\components`.
-2. component files in the components folder called `pubsub.yaml` and `statestore.yaml`.
-3. default config file `$HOME/.dapr/config.yaml` for Linux/MacOS or for Windows at `%USERPROFILE%\.dapr\config.yaml` to enable tracing on `dapr init` call. Can be overridden with the `--config` flag on `dapr run`.
+1. an empty components folder which is later used during `dapr run` unless the `--components-path` option is provided. For Linux/MacOS, the default components folder path is `$HOME/.dapr/components` and for Windows it is `%USERPROFILE%\.dapr\components`.
+2. default config file `$HOME/.dapr/config.yaml` for Linux/MacOS or for Windows at `%USERPROFILE%\.dapr\config.yaml`. Can be overridden with the `--config` flag on `dapr run`.
 
-> Note: To emulate *online* dapr initialization using `dapr init`, you can also run redis/zipkin containers as follows:
+> Note: To emulate *online* dapr initialization using `dapr init`, you can also run redis/zipkin containers as follows. You would also need to update the default config file to enable tracing and add component files in the components folder to load them on `dapr init` call:
 ```
 1. docker run --name "dapr_zipkin" --restart always -d -p 9411:9411 openzipkin/zipkin
 2. docker run --name "dapr_redis" --restart always -d -p 6379:6379 redislabs/rejson


### PR DESCRIPTION
This PR updates Readme to remove incorrect description that component files are created in airgap dapr init. It also updates workflow to use .txt file for Readme instead of markdown. 

Please reference the issue this PR will close: #14, #12 