### PR TITLE
Stop bundling the deprecated Dapr dashboard binary

### DIFF
--- a/.github/scripts/build_daprbundle.py
+++ b/.github/scripts/build_daprbundle.py
@@ -31,14 +31,12 @@ import stat
 # GitHub Organization and repo name to download release
 GITHUB_ORG="dapr"
 GITHUB_DAPR_REPO="dapr"
-GITHUB_DASHBOARD_REPO="dashboard"
 GITHUB_CLI_REPO="cli"
 
 # Dapr binaries filename
 DAPRD_FILENAME="daprd"
 PLACEMENT_FILENAME="placement"
 SENTRY_FILENAME="sentry"
-DASHBOARD_FILENAME="dashboard"
 CLI_FILENAME="dapr"
 SCHEDULER_FILENAME="scheduler"
 DAPRBUNDLE_FILENAME="daprbundle"
@@ -52,7 +50,7 @@ DAPR_IMAGE="daprio/dapr"
 detailsFileName="details.json"
 
 
-global runtime_os,runtime_arch,runtime_ver,dashboard_ver,cli_ver,added_files
+global runtime_os,runtime_arch,runtime_ver,cli_ver,added_files
 
 
 # Returns latest release/pre-release version of the given repo from GitHub (e.g. `dapr`)
@@ -132,14 +130,13 @@ def downloadBinary(repo, fileBase, version, out_dir):
 
     print(f"Downloaded {url} to {downloadPath}")
 
-# Downloads all required dapr binaries (`daprd`,`placement`,`dashboard`) in `BIN_DIR` subfolder and dapr cli (`dapr`) in `dir` folder
+# Downloads all required dapr binaries (`daprd`,`placement`,`sentry`,`scheduler`) in `BIN_DIR` subfolder and dapr cli (`dapr`) in `dir` folder
 def downloadBinaries(dir):
     bin_dir = os.path.join(dir,BIN_DIR)
     downloadBinary(GITHUB_DAPR_REPO,DAPRD_FILENAME,runtime_ver,bin_dir)
     downloadBinary(GITHUB_DAPR_REPO,PLACEMENT_FILENAME,runtime_ver,bin_dir)
     downloadBinary(GITHUB_DAPR_REPO,SENTRY_FILENAME,runtime_ver,bin_dir)
     downloadBinary(GITHUB_DAPR_REPO,SCHEDULER_FILENAME,runtime_ver,bin_dir)
-    downloadBinary(GITHUB_DASHBOARD_REPO,DASHBOARD_FILENAME,dashboard_ver,bin_dir)
     downloadBinary(GITHUB_CLI_REPO,CLI_FILENAME,cli_ver,dir)
 
     cli_filepath = os.path.join(dir,binaryFileName(CLI_FILENAME))
@@ -186,12 +183,11 @@ def downloadDockerImages(dir):
 
 # Parses command line arguments
 def parseArguments():
-    global runtime_os,runtime_arch,runtime_ver,dashboard_ver,cli_ver,ARCHIVE_DIR,added_files
+    global runtime_os,runtime_arch,runtime_ver,cli_ver,ARCHIVE_DIR,added_files
     all_args = argparse.ArgumentParser()
     all_args.add_argument("--runtime_os",required=True,help="Runtime OS: [windows/linux/darwin]")
     all_args.add_argument("--runtime_arch",required=True,help="Runtime Architecture: [amd64/arm/arm64]")
     all_args.add_argument("--runtime_ver",default="latest",help="Dapr Runtime Version: default=latest e.g. 1.6.0")
-    all_args.add_argument("--dashboard_ver",default="latest",help="Dapr Dashboard Version: default=latest e.g. 0.9.0")
     all_args.add_argument("--cli_ver",default="latest",help="Dapr CLI Version: default=latest e.g. 1.6.0")
     all_args.add_argument("--archive_dir",default="archive",help="Output Archive directory: default=archive")
     all_args.add_argument("--added_files",default="",help="Extra files to be included in the archive seaparated by comma")
@@ -200,15 +196,12 @@ def parseArguments():
     runtime_os = str(args['runtime_os'])
     runtime_arch = str(args['runtime_arch'])
     runtime_ver = str(args["runtime_ver"])
-    dashboard_ver = str(args["dashboard_ver"])
     cli_ver = str(args["cli_ver"])
     ARCHIVE_DIR = str(args["archive_dir"])
     added_files = str(args["added_files"])
 
     if runtime_ver == "latest" or runtime_ver == "":
         runtime_ver = getLatestRelease(GITHUB_DAPR_REPO)
-    if dashboard_ver == "latest" or dashboard_ver == "":
-        dashboard_ver = getLatestRelease(GITHUB_DASHBOARD_REPO)
     if cli_ver == "latest" or cli_ver == "":
         cli_ver = getLatestRelease(GITHUB_CLI_REPO)
 
@@ -226,7 +219,6 @@ def write_details(dir):
     daprImageFileName = getFileName(daprImageName)
     details = {
         "daprd" : runtime_ver,
-        "dashboard": dashboard_ver,
         "cli": cli_ver,
         "daprBinarySubDir": BIN_DIR,
         "dockerImageSubDir": IMAGE_DIR,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,11 +34,6 @@ on:
         required: false
         default: "latest"
         type: string
-      dashboard_ver:
-        description: "Dapr Dashboard Version"
-        required: false
-        default: "latest"
-        type: string
 
   pull_request:
     branches:
@@ -98,7 +93,7 @@ jobs:
 
       - name: Create and Archive bundle in workflow_dispatch
         if: github.event_name == 'workflow_dispatch'
-        run: python ./.github/scripts/build_daprbundle.py --runtime_os=${{matrix.target_os}} --runtime_arch=${{matrix.target_arch}} --archive_dir=${{env.ARCHIVE_DIR}} --runtime_ver=${{inputs.runtime_ver}} --cli_ver=${{inputs.cli_ver}} --dashboard_ver=${{inputs.dashboard_ver}} --added_files=${{env.README_TXT_FILE}}
+        run: python ./.github/scripts/build_daprbundle.py --runtime_os=${{matrix.target_os}} --runtime_arch=${{matrix.target_arch}} --archive_dir=${{env.ARCHIVE_DIR}} --runtime_ver=${{inputs.runtime_ver}} --cli_ver=${{inputs.cli_ver}} --added_files=${{env.README_TXT_FILE}}
 
       - name: Create and Archive bundle without workflow_dispatch
         if: github.event_name != 'workflow_dispatch'

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Dapr Installer Bundle
 
 ## Overview
-Dapr Installer Bundle contains CLI, runtime and dashboard packaged together. This eliminates the need to download binaries as well as docker images when initializing Dapr locally, especially in airgap/offline environment. The bundle structure is fixed and is as follows:
+Dapr Installer Bundle contains CLI and runtime packaged together. This eliminates the need to download binaries as well as docker images when initializing Dapr locally, especially in airgap/offline environment. The bundle structure is fixed and is as follows:
 ```
 daprbundle
 ├── dapr
 ├── dist
 │   ├── daprd_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
-│   ├── dashboard_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
 │   ├── placement_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
 │   ├── sentry_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
 │   ├── scheduler_<runtime_os>_<runtime_arch>.tar.gz (`.zip` for windows)
@@ -20,7 +19,6 @@ daprbundle
 ```
   {
     "daprd": <runtime_ver>,
-    "dashboard": <dashboard_ver>,
     "cli": <cli_ver>,
     "daprBinarySubDir": <binaries_subdirectoryName>,
     "dockerImageSubDir": <images_subdirectoryName>,


### PR DESCRIPTION
## Summary

- The `dapr/dashboard` repository is archived and no longer maintained; bundling it is a dead end.
- Remove all dashboard download, versioning, and packaging logic from the build script (`build_daprbundle.py`): `GITHUB_DASHBOARD_REPO`, `DASHBOARD_FILENAME` constants, the `downloadBinary(...dashboard...)` call, the `"dashboard"` key in `details.json`, and the `--dashboard_ver` CLI argument.
- Remove the `dashboard_ver` `workflow_dispatch` input and the `--dashboard_ver=...` argument passed to the build script in `release.yaml`.
- Update `README.md` to reflect that the bundle now ships CLI + runtime only (no dashboard artifact or `details.json` dashboard field).

## Notes

The Dapr CLI is being updated in a parallel PR to tolerate a `details.json` that does not contain a `dashboard` field, so existing `dapr init --from-dir` workflows will not break once both changes land.

## Test plan

- [ ] Trigger the `dapr_bundle` workflow via `workflow_dispatch` (without a `dashboard_ver` input — verify it is gone from the UI).
- [ ] Confirm the produced `details.json` inside the archive no longer contains a `dashboard` key.
- [ ] Confirm no `dashboard_*` artifact is present in the `dist/` subdirectory of the bundle.
- [ ] `python3 -m py_compile .github/scripts/build_daprbundle.py` passes locally.